### PR TITLE
QoL: Include entrances for auto tab switching with ER

### DIFF
--- a/scripts/autotracking/archipelago.lua
+++ b/scripts/autotracking/archipelago.lua
@@ -498,7 +498,12 @@ function onMap(stage_name)
             local map_switch_dungeons_only_setting = Tracker:FindObjectForCode("setting_map_tracking_dungeons_only")
             if map_switch_dungeons_only_setting then
                 if not map_switch_dungeons_only_setting.Active or tab_name ~= "The Great Sea" then
-                    Tracker:UiHint("ActivateTab", tab_name)
+					if tab_name == "The Great Sea" and ENTRANCE_RANDO_ENABLED then
+						Tracker:UiHint("ActivateTab", "Entrances")
+						Tracker:UiHint("ActivateTab", "+ The Great Sea")
+					else
+						Tracker:UiHint("ActivateTab", tab_name)
+					end
                 end
                 -- Always set the last activated tab, so that if the player has the setting on that only switches when
                 -- entering a dungeon, enters a dungeon, leaves, and then re-enters, the map will switch to the dungeon


### PR DESCRIPTION
Use Entrances + The Great Sea as auto tab instead of just The Great Sea when using ER.

This is a little change I made for myself a while ago since I found myself switching back to that manually everytime but I also wanted to auto switch to the great sea and I figured it might a general nice QoL improvement for the pack.